### PR TITLE
Daha da millileştirme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Cigdem
+# Çiğdem
 
 ![alt text](https://raw.githubusercontent.com/kozdincer/cigdem/master/sunflower_seed.jpg "Baş koymuşum Türkiyemin yoluna.")
-Milli linux çekirdeği projesi.
+Milli linuks çekirdeği projesi.
 
 ## Çiğdem nedir?
 
-Halkın, milli çekirdek isteğini baz alarak geliştirilen, yerli linux çekirdeğidir.
+Halkın, milli çekirdek isteğini baz alarak geliştirilen, yerli linuks çekirdeğidir.
 
 ## Hangi Donanımlar ile çalışır?
 
@@ -13,16 +13,16 @@ Tüm yerli donanımların dışında, 32-bit x86, Compaq Alpha AXP, Sun SPARC ve
 
 ## Yapılandırma
 
-* "make config"      Düz metin arayüzü.
-* "make menuconfig"  Metin tabanlı renkli menü.
-* "make nconfig"     Gelişmiş metin tabanlı renkli menü.
-* "make xconfig"     Qt tabanlı yapılandırma aracı.
-* "make milli"       Milli yapılandırma arayüzü.
+* "yap config"       Düz metin arayüzü.
+* "yap menuconfig"   Metin tabanlı renkli menü.
+* "yap nconfig"      Gelişmiş metin tabanlı renkli menü.
+* "yap xconfig"      Qt tabanlı yapılandırma aracı.
+* "yap milli"        Milli yapılandırma arayüzü.
 
 ## Derleme
 
-* "make v=1 all"     Normal derleme.
-* "make v=1 milli"   Milli derleme.
+* "yap v=1 all"      Normal derleme.
+* "yap v=1 milli"    Milli derleme.
 
 ## Katkıcılar
 
@@ -31,3 +31,7 @@ Tüm millet.
 ## Nasıl katkı verebilirim?
 
 ![alt text](https://raw.githubusercontent.com/kozdincer/cigdem/master/milli.png "Irmağının akışına ölürüm.")
+
+## Lisans
+
+Sadece Türk Milleti geliştirebilir. Diğer milletler (dış mihraklar) kodumuza karışamaz. Milletin sabrı test edilmemelidir.


### PR DESCRIPTION
- Milli değerlerimize sahip çıkmamız amacıyla ve alfabemizde "x" harfinin bulunmaması nedeniyle "Linux" kelimesini fonetik değerlerimize sahip çıkılarak "Linuks" olarak değiştirilmesi.
- Lisansın belirlenip herkesin haddini bilmesi ve Türk geliştirici milletinin sabrının test edilmemesi.
- `make` gibi dilimizde var olmayan **mel'un** sözcüklerin kaldırılarak daha da milli bir hal alması.
